### PR TITLE
fix: pack HTTP version as python proxy does

### DIFF
--- a/src/route/app.rs
+++ b/src/route/app.rs
@@ -199,9 +199,9 @@ fn serialize_version<S>(version: &HttpVersion, se: S) -> Result<S::Ok, S::Error>
     where S: Serializer
 {
     let v = if let &HttpVersion::Http11 = version {
-        "1"
+        "1.1"
     } else {
-        "0"
+        "1.0"
     };
 
     se.serialize_str(v)


### PR DESCRIPTION
HTTP version is serialized as 1.1 or 1.0

https://github.com/cocaine/cocaine-tools/blob/master/cocaine/proxy/helpers.py#L109
Also native proxy did it  the same way