### PR TITLE
feat: perf route is now optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cocaine-http-proxy"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.20.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocaine-http-proxy"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Evgeny Safronov <division494@gmail.com>"]
 license = "MIT"
 description = "HTTP proxy for Cocaine APE Cloud"

--- a/config.yaml
+++ b/config.yaml
@@ -89,3 +89,11 @@ pool:
   services:
     echo:
       limit: 4
+
+# Optional load testing plugin.
+# When activated, adds a terminal route to the end of routing list, which
+# accepts all requests and performs request to the Geobase service. Used mainly
+# for performance measuring.
+# May be completely omitted.
+load_testing:
+  enabled: false

--- a/src/config.rs
+++ b/src/config.rs
@@ -185,6 +185,11 @@ impl TimeoutsConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+struct LoadTestingConfig {
+    enabled: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Config {
     network: NetworkConfig,
     threads: Option<usize>,
@@ -196,6 +201,7 @@ pub struct Config {
     tracing: TracingConfig,
     timeout: u64,
     timeouts: TimeoutsConfig,
+    load_testing: Option<LoadTestingConfig>,
 }
 
 impl Config {
@@ -264,5 +270,10 @@ impl Config {
 
     pub fn timeouts(&self) -> &TimeoutsConfig {
         &self.timeouts
+    }
+
+    /// Returns `true` when a load testing plugin is enabled.
+    pub fn is_load_testing_enabled(&self) -> bool {
+        self.load_testing.as_ref().map(|v| v.enabled).unwrap_or(false)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,11 @@ pub fn run(config: Config) -> Result<(), Box<error::Error>> {
     router.add(Arc::new(AppRoute::new(dispatch.clone(), logging.access().clone())
         .with_tracing_header(config.tracing().header().to_owned())));
     router.add(Arc::new(JsonRpc::new(dispatch.clone(), logging.access().clone())));
-    router.add(Arc::new(PerfRoute::new(dispatch.clone(), logging.access().clone())));
+
+    if config.is_load_testing_enabled() {
+        router.add(Arc::new(PerfRoute::new(dispatch.clone(), logging.access().clone())));
+        cocaine_log!(logging.common(), Severity::Debug, "enabled performance measuring route");
+    }
 
     let factory = ProxyServiceFactoryFactory::new(
         dispatch.into_senders(),


### PR DESCRIPTION
It is turned off by default, but can be activated using `load_testing`
setting in the config.