### PR TITLE
v0.3.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cocaine-http-proxy"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocaine 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocaine-http-proxy"
-version = "0.3.10"
+version = "0.3.11"
 authors = ["Evgeny Safronov <division494@gmail.com>"]
 license = "MIT"
 description = "HTTP proxy for Cocaine APE Cloud"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+cocaine-http-proxy (0.3.11) trusty; urgency=low
+
+  * Changed: format trace id as a hex.
+    Change `trace_id` attribute formatting, making it hex to be able to
+    properly match our Cocaine traces in a single format.
+    The old unformatted trace attribute is now formatted using `trace`.
+    Moreover this commit removes `request_id` attribute, as it is no longer
+    needed.
+
+ -- Evgeny Safronov <division494@gmail.com>  Thu, 24 Aug 2017 16:37:43 +0300
+
 cocaine-http-proxy (0.3.10) trusty; urgency=low
 
   * Changed: update CLAP dependency.

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -105,8 +105,8 @@ impl<L: Log> AccessLogger<L> {
         cocaine_log!(log, Severity::Debug, "processing HTTP request"; {
             service: service,
             event: event,
-            trace_id: trace,
-            request_id: format!("{:016x}", trace),
+            trace: trace,
+            trace_id: format!("{:016x}", trace),
             request: format!("{:?}", SafeRequestDebug(req)),
         });
 
@@ -128,8 +128,8 @@ impl<L: Log> AccessLogger<L> {
         let elapsed_ms = (elapsed.as_secs() * 1000000000 + elapsed.subsec_nanos() as u64) as f64 / 1e6;
 
         cocaine_log!(self.log, Severity::Info, "request finished in {:.3} ms", elapsed_ms; {
-            request_id: format!("{:016x}", self.trace),
-            trace_id: self.trace,
+            trace: self.trace,
+            trace_id: format!("{:016x}", self.trace),
             duration: elapsed_ms / 1000.0,
             method: self.method.to_string(),
             uri: self.uri.to_string(),

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -261,7 +261,7 @@ impl PoolTask {
         let log = self.log.clone();
         let cfg = self.cfg.config(&name);
 
-        let mut pool = {
+        let pool = {
             let name = name.clone();
             self.pool.entry(name.clone())
                 .or_insert_with(|| ServicePool::new(name, cfg, handle, tx, log))


### PR DESCRIPTION
Changed:
- Format trace id as a hex.
  This release changes `trace_id` attribute formatting, making it hex to be able to properly match our Cocaine traces in a single format. The old unformatted trace attribute is now formatted using `trace`. Moreover this commit removes `request_id` attribute, as it is no longer needed.

