### PR TITLE
feat: tracing policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cocaine-http-proxy"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocaine 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cocaine-http-proxy"
-version = "0.3.11"
+version = "0.3.12"
 authors = ["Evgeny Safronov <division494@gmail.com>"]
 license = "MIT"
 description = "HTTP proxy for Cocaine APE Cloud"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+cocaine-http-proxy (0.3.12) trusty; urgency=low
+
+  * Added: tracing policy header.
+    This commit allows to manually specify whether a request should be
+    traced verbosely using `X-Cocaine-Tracing-Policy` header.
+    It allows `Auto` value to fall back to default dice rolling policy as
+    like as specifying real value in [0; 1] range to calculate trace bit
+    chance.
+    For example `X-Cocaine-Tracing-Policy: 1.0` forces the request to be
+    fully traced.
+
+ -- Evgeny Safronov <division494@gmail.com>  Thu, 24 Aug 2017 17:56:03 +0300
+
 cocaine-http-proxy (0.3.11) trusty; urgency=low
 
   * Changed: format trace id as a hex.


### PR DESCRIPTION
This commits allows to manually specify whether a request should be
traced verbosely using `X-Cocaine-Tracing-Policy` header.
It allows `Auto` value to fall back to default dice rolling policy as
like as specifying real value in [0; 1] range to calculate trace bit
chance.

For example `X-Cocaine-Tracing-Policy: 1.0` forces the request to be
fully traced.